### PR TITLE
fix: remove logs directory dependency from build process

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -68,6 +68,10 @@ jobs:
           pip install -r requirements.txt
           pip install pyinstaller
       
+      - name: Modify spec file to remove logs directory dependency
+        run: |
+          (Get-Content CaughtUP.spec) -replace "'logs', 'logs'", "'build_resources', 'build_resources'" | Set-Content CaughtUP.spec
+      
       - name: Build Windows executable
         run: |
           pyinstaller CaughtUP.spec
@@ -105,12 +109,9 @@ jobs:
           pip install -r requirements.txt
           pip install pyinstaller
       
-      - name: Create required directories
+      - name: Modify spec file to remove logs directory dependency
         run: |
-          mkdir -p logs
-          mkdir -p build_resources
-          # Ensure any other directories specified in spec file exist
-          touch logs/.gitkeep
+          sed -i '' "s/'logs', 'logs'/'build_resources', 'build_resources'/g" CaughtUP.spec
       
       - name: Build macOS app
         run: |

--- a/CaughtUP.spec
+++ b/CaughtUP.spec
@@ -16,7 +16,6 @@ a = Analysis(
     datas=[
         # Include build resources in the bundle
         ('build_resources', 'build_resources'),
-        ('logs', 'logs'),
     ],
     # Only specify the exact imports needed
     hiddenimports=[


### PR DESCRIPTION
This pull request includes changes to the build and release workflow to remove the dependency on the logs directory and update the spec file accordingly.

Changes to build and release workflow:

* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bR71-R74): Modified the spec file to remove the logs directory dependency and replaced it with the build_resources directory. This change was applied to both Windows and macOS build steps. [[1]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bR71-R74) [[2]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL108-R114)

Changes to spec file:

* [`CaughtUP.spec`](diffhunk://#diff-0f1c2bd4c5bc1997fb67db84e6c86f4d5b794455e4df9ea0a66ebe96d63af1cbL19): Removed the logs directory from the `datas` list to reflect the updated dependency.