### PR TITLE
ci: switch from DMG to PKG installer for macOS build

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -39,29 +39,25 @@ jobs:
           draft: true
           prerelease: false
           body: |
-              ## CaughtUP Release v${{ steps.get_version.outputs.version }}
-              
-              Automated build from the main branch.
-              
-              ### Downloads
-              - Windows: CaughtUP-Windows-${{ steps.get_version.outputs.version }}.zip
-              - macOS: CaughtUP-macOS-${{ steps.get_version.outputs.version }}.zip
-              
-              ### macOS Installation Instructions
-              Due to Apple's security features (Gatekeeper), you'll need to follow these steps to open the app:
-              
-              1. Extract the zip file
-              2. Right-click (or Control+click) on CaughtUP.app
-              3. Select "Open" from the context menu
-              4. When the security warning appears, click "Open"
-              
-              If the above method doesn't work, open Terminal and run:
-              
-              ```bash
-              xattr -cr /path/to/CaughtUP.app
-              ```
-              Replace `/path/to/CaughtUP.app` with the actual path to the app.
-              *This is an automatically generated draft release. Please add release notes before publishing.*
+            ## CaughtUP Release v${{ steps.get_version.outputs.version }}
+        
+            Automated build from the main branch.
+            
+            ### Downloads
+            - Windows: CaughtUP-Windows-${{ steps.get_version.outputs.version }}.zip
+            - macOS: CaughtUP-macOS-${{ steps.get_version.outputs.version }}.pkg
+            
+            ### macOS Installation Instructions
+            1. Download the .pkg installer
+            2. Double-click to launch the installer
+            3. Follow the installation wizard
+            4. After installation, find "Open CaughtUP First Time.command" in Applications
+            5. Right-click on this file and select "Open"
+            6. When the security warning appears, click "Open"
+            
+            After first launch, you can open CaughtUP normally.
+            
+            *This is an automatically generated draft release. Please add release notes before publishing.*
 
   build-windows:
     needs: create-release
@@ -122,7 +118,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pyinstaller
-          brew install create-dmg || true
       
       - name: Modify spec file to remove logs directory dependency
         run: |
@@ -132,51 +127,43 @@ jobs:
         run: |
           pyinstaller CaughtUP.spec
       
-      # This step removes quarantine attributes safely
-      - name: Remove quarantine and extended attributes
+      - name: Prepare installer resources
         run: |
-          # Make sure the binary is definitely executable
-          chmod -R +x dist/CaughtUP.app/Contents/MacOS/
+          # Create directories
+          mkdir -p pkg_resources
+          mkdir -p scripts
           
-          # Clear all extended attributes if they exist (ignore errors)
-          xattr -cr dist/CaughtUP.app || true
+          # Copy the postinstall script
+          cp installer/macos/postinstall scripts/
+          chmod +x scripts/postinstall
           
-          # For good measure, try to remove specific quarantine attribute (ignore errors)
-          xattr -d com.apple.quarantine dist/CaughtUP.app || true
+          # Copy the welcome text and update version
+          sed "s/VERSION/${{ needs.create-release.outputs.version }}/g" installer/macos/welcome.txt > pkg_resources/welcome.txt
+          
+          # Copy distribution.xml
+          cp installer/macos/distribution.xml ./
       
-      # Create a simple DMG file
-      - name: Create DMG
+      - name: Create PKG installer
         run: |
-          # Create a temporary directory for DMG contents
-          mkdir -p dmg_temp
-          cp -R dist/CaughtUP.app dmg_temp/
+          # Build component package
+          pkgbuild --root dist/ \
+                  --identifier com.vidaldl.caughtup \
+                  --version ${{ needs.create-release.outputs.version }} \
+                  --install-location /Applications \
+                  --scripts scripts \
+                  component.pkg
           
-          # Create a link to Applications folder
-          ln -s /Applications dmg_temp/
-          
-          # Create the DMG using a simpler approach that's less likely to fail
-          hdiutil create -volname "CaughtUP-${{ needs.create-release.outputs.version }}" \
-            -srcfolder dmg_temp -ov -format UDZO \
-            CaughtUP-macOS.dmg
-          
-          # Verify the DMG was created
-          ls -la CaughtUP-macOS.dmg
+          # Build distribution package
+          productbuild --distribution distribution.xml \
+                      --resources pkg_resources \
+                      CaughtUP-macOS.pkg
       
-      # Fix DMG permissions
-      - name: Fix DMG permissions
-        run: |
-          # Make sure DMG is readable
-          chmod 644 CaughtUP-macOS.dmg
-          
-          # Try to remove quarantine from DMG (ignore errors)
-          xattr -c CaughtUP-macOS.dmg || true
-      
-      - name: Upload macOS artifact to release
+      - name: Upload macOS installer
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./CaughtUP-macOS.dmg
-          asset_name: CaughtUP-macOS-${{ needs.create-release.outputs.version }}.dmg
-          asset_content_type: application/x-apple-diskimage
+          asset_path: ./CaughtUP-macOS.pkg
+          asset_name: CaughtUP-macOS-${{ needs.create-release.outputs.version }}.pkg
+          asset_content_type: application/x-newton-compatible-pkg

--- a/installer/macos/distribution.xml
+++ b/installer/macos/distribution.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <title>CaughtUP</title>
+    <organization>com.vidaldl</organization>
+    <domains enable_anywhere="true"/>
+    <options customize="never" require-scripts="true" hostArchitectures="x86_64,arm64"/>
+    
+    <welcome file="welcome.txt"/>
+    <background alignment="center" scaling="proportional"/>
+    
+    <pkg-ref id="com.vidaldl.caughtup"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.vidaldl.caughtup"/>
+        </line>
+    </choices-outline>
+    
+    <choice id="default"/>
+    <choice id="com.vidaldl.caughtup" visible="false">
+        <pkg-ref id="com.vidaldl.caughtup"/>
+    </choice>
+    
+    <pkg-ref id="com.vidaldl.caughtup" version="0" onConclusion="none">component.pkg</pkg-ref>
+</installer-gui-script>

--- a/installer/macos/postinstall
+++ b/installer/macos/postinstall
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Remove quarantine attributes
+xattr -cr "/Applications/CaughtUP.app" || true
+
+# Create a first-launch helper script
+cat > "/Applications/Open CaughtUP First Time.command" << 'EOL'
+#!/bin/bash
+echo "Opening CaughtUP for the first time..."
+xattr -cr "/Applications/CaughtUP.app"
+open "/Applications/CaughtUP.app"
+rm "$0"
+EOL
+
+chmod +x "/Applications/Open CaughtUP First Time.command"

--- a/installer/macos/welcome.txt
+++ b/installer/macos/welcome.txt
@@ -1,0 +1,13 @@
+CaughtUP Course Backup Manager for Canvas LMS
+Version: VERSION
+
+IMPORTANT INSTALLATION INSTRUCTIONS:
+
+1. After installation completes, locate "Open CaughtUP First Time.command" in your Applications folder
+2. Right-click on this file and select "Open"
+3. When prompted, click "Open" again
+
+This helper script will securely launch CaughtUP for the first time.
+Future launches can be done normally by clicking on the CaughtUP app.
+
+Thank you for installing CaughtUP!


### PR DESCRIPTION
This pull request includes significant changes to the build and release process for the macOS version of the CaughtUP application. The most important changes involve switching from a DMG to a PKG installer, updating installation instructions, and modifying the build workflow to accommodate these changes.

Changes to the installer format and instructions:

* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL48-L63): Changed the macOS installer from a DMG to a PKG format and updated the corresponding download link and installation instructions.
* [`installer/macos/postinstall`](diffhunk://#diff-090fc7ecb292fd30f227a01a616e79ba0f2dc76efdbe4e33a1ba3dabadd78d67R1-R14): Added a post-installation script to remove quarantine attributes and create a helper script for the first launch of the application.
* [`installer/macos/welcome.txt`](diffhunk://#diff-9412254c03c66e9b334cec8640117defce0a3c10bd399abc97d06340468c93b5R1-R13): Added a welcome text file with important installation instructions for users.

Modifications to the build workflow:

* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL135-R169): Removed the step for creating a DMG file and added steps for preparing installer resources and creating the PKG installer. [[1]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL135-R169) [[2]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL125)
* [`installer/macos/distribution.xml`](diffhunk://#diff-c99444d108273869ef9e1403c321db2b890340252de2439ebee1c9edb1e9132eR1-R24): Added a new distribution XML file to define the PKG installer structure and options.