### PR TITLE
chore: go back from pkg to dmg in GitHub Workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -148,7 +148,7 @@ jobs:
           echo "Checking for any remaining extended attributes:"
           find dist/CaughtUP.app -exec xattr {} \; | grep -v "^$"
       
-      # Create a DMG file instead of ZIP
+      # Create a DMG file instead of ZIPs
       - name: Create DMG
         run: |
           # Create a temporary directory for DMG contents


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/build-and-release.yml` file. The change updates a comment to correctly refer to creating a DMG file instead of ZIPs.

* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL151-R151): Updated the comment to correctly refer to creating a DMG file instead of ZIPs.