### PR TITLE
ci: signing to app and pkg added

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -132,21 +132,21 @@ jobs:
         run: |
           pyinstaller CaughtUP.spec
       
-      # This step removes quarantine attributes safely
-      - name: Remove quarantine and extended attributes
+      # Ad-Hoc signing step
+      - name: Ad-Hoc Sign the .app bundle
         run: |
-          # Make sure the binary is definitely executable
+          # Remove any existing signature
+          codesign --remove-signature "dist/CaughtUP.app" || true
+          
+          # Sign with ad-hoc signature (the dash "-" means ad-hoc signing)
+          codesign --force --deep --sign - --timestamp --options runtime "dist/CaughtUP.app"
+          
+          # Verify signature
+          codesign -vvv --deep --strict "dist/CaughtUP.app"
+          
+          # Make sure the binary is executable
           chmod -R +x dist/CaughtUP.app/Contents/MacOS/
-          
-          # Clear all extended attributes if they exist (ignore errors)
-          xattr -cr dist/CaughtUP.app || true
-          
-          # For good measure, try to remove specific quarantine attribute (ignore errors)
-          xattr -d com.apple.quarantine dist/CaughtUP.app || true
       
-
-      # Create a DMG file instead of ZIPs
-
       - name: Create DMG
         run: |
           # Create a temporary directory for DMG contents
@@ -164,14 +164,14 @@ jobs:
           # Verify the DMG was created
           ls -la CaughtUP-macOS.dmg
       
-      # Fix DMG permissions
-      - name: Fix DMG permissions
+      # Sign the DMG file
+      - name: Sign DMG
         run: |
+          # Sign the DMG with ad-hoc signature
+          codesign --force --sign - CaughtUP-macOS.dmg
+          
           # Make sure DMG is readable
           chmod 644 CaughtUP-macOS.dmg
-          
-          # Try to remove quarantine from DMG (ignore errors)
-          xattr -c CaughtUP-macOS.dmg || true
       
       - name: Upload macOS artifact to release
         uses: actions/upload-release-asset@v1

--- a/CaughtUP.spec
+++ b/CaughtUP.spec
@@ -105,5 +105,8 @@ elif is_macos:
             'CFBundleName': 'CaughtUP',
             'NSPrincipalClass': 'NSApplication',  # Required for proper macOS app behavior
             'LSMinimumSystemVersion': '10.13',    # Set minimum macOS version
+            'NSHumanReadableCopyright': 'Copyright © 2025 David Leo Vidal',
+            'NSAppleEventsUsageDescription': 'This app requires access to automate certain tasks',
+            'CFBundleDocumentTypes': [],  # Empty array to avoid errors
         }
     )


### PR DESCRIPTION
This pull request includes changes to the build and release workflow for the `CaughtUP` macOS application, as well as updates to the `CaughtUP.spec` file. The most important changes involve adding ad-hoc signing steps and updating macOS application metadata.

### Build and Release Workflow Improvements:
* [`.github/workflows/build-and-release.yml`](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL135-R148): Replaced quarantine attribute removal steps with ad-hoc signing steps for the `.app` bundle and DMG file, ensuring proper signing and verification. [[1]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL135-R148) [[2]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL167-L175)

### macOS Application Metadata Updates:
* [`CaughtUP.spec`](diffhunk://#diff-0f1c2bd4c5bc1997fb67db84e6c86f4d5b794455e4df9ea0a66ebe96d63af1cbR108-R110): Added `NSHumanReadableCopyright`, `NSAppleEventsUsageDescription`, and `CFBundleDocumentTypes` to the macOS application metadata to comply with macOS requirements and avoid errors.